### PR TITLE
When invalid Hex provided... #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function yiq (colorHex, options = {}) {
   const dark  = options.dark || '#000'
 
   if (! /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(colorHex)) {
-    return '#fff'
+    console.warn(`You provided an invalid Hex color value`);
+    return white
   }
 
   if (colorHex.length === 4) {


### PR DESCRIPTION
Hi,

As per discussion on #3. 
This PR provides the warning and returns the `options.white` instead of an arbitrary `#fff`. 
I did not implement the other suggestions as I'm not sure how you would expect the trappable aspects to be implemented nor am I familiar with the test suite.