### PR TITLE
Fix documentation of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The second argument (options) should be used to define the colors that the funct
 ```typescript
 yiq('#fff', {
   white: '#f0f0f0',
-  dark: '#333'
+  black: '#333'
 }) // #333
 ```
 


### PR DESCRIPTION
Readme currently gives example as 

```typescript
yiq('#fff', {
  white: '#f0f0f0',
  dark: '#333'
}) // #333
```

however above it gives example of options as `{white, black}` 

this therefore changes the example to be

```typescript
yiq('#fff', {
  white: '#f0f0f0',
  black: '#333'
}) // #333
```