### PR TITLE
Add threshold option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ console.log(yiq('#000')) // #fff
 function colorYiq(
   colorHex: string,
   options?: {
-    light: string
-    dark: string
+    colors? {
+      light: string
+      dark: string
+    },
+    threshold?: number
   }
 ): string
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ function colorYiq(
 ): string
 ```
 
-The second argument (options) should be used to define the colors that the function will return:
+The second argument (options) can be used to define the colors that the function will return:
 
 ```typescript
 yiq('#fff', {
@@ -53,10 +53,16 @@ yiq('#fff', {
 }) // #333
 ```
 
+It can also be used to define the threshold YIQ value at which the function switches between white and black:
+```typescript
+yiq('#36d386', { threshold: 156 }) // #fff
+```
+
 The default options are:
 
 - `options.white`: `#fff`;
-- `options.black`: `#000`.
+- `options.black`: `#000`;
+- `options.threshold`: 128.
 
 ## Authors and License
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ console.log(yiq('#000')) // #fff
 
 ### `yiq`
 
-`yiq` — Returns a light color when a color is dark and dark color when a color is light.
+`yiq` — Returns a light color when a color is dark and a dark color when a color is light.
 
 #### Description
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ The second argument (options) can be used to define the colors that the function
 
 ```typescript
 yiq('#fff', {
-  white: '#f0f0f0',
-  black: '#333'
+  colors: {
+    white: '#f0f0f0',
+    black: '#333'
+  }
 }) // #333
 ```
 
@@ -60,8 +62,8 @@ yiq('#36d386', { threshold: 156 }) // #fff
 
 The default options are:
 
-- `options.white`: `#fff`;
-- `options.black`: `#000`;
+- `options.colors.white`: `#fff`;
+- `options.colors.black`: `#000`;
 - `options.threshold`: 128.
 
 ## Authors and License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YIQ
 
-Returns white when a color is dark and black when a color is light. 🎨
+Returns light when a color is dark and dark when a color is light. 🎨
 
 [![Build Status](https://circleci.com/gh/lffg/yiq.svg?style=svg)](https://circleci.com/gh/lffg/yiq)
 [![NPM](https://img.shields.io/npm/v/yiq.svg?logo=npm)](https://npmjs.org/package/yiq)
@@ -30,7 +30,7 @@ console.log(yiq('#000')) // #fff
 
 ### `yiq`
 
-`yiq` — Returns a light color when a color is dark and black color when a color is light.
+`yiq` — Returns a light color when a color is dark and dark color when a color is light.
 
 #### Description
 
@@ -38,8 +38,8 @@ console.log(yiq('#000')) // #fff
 function colorYiq(
   colorHex: string,
   options?: {
-    white: string
-    black: string
+    light: string
+    dark: string
   }
 ): string
 ```
@@ -49,21 +49,21 @@ The second argument (options) can be used to define the colors that the function
 ```typescript
 yiq('#fff', {
   colors: {
-    white: '#f0f0f0',
-    black: '#333'
+    light: '#f0f0f0',
+    dark: '#333'
   }
 }) // #333
 ```
 
-It can also be used to define the threshold YIQ value at which the function switches between white and black:
+It can also be used to define the threshold YIQ value at which the function switches between light and dark:
 ```typescript
 yiq('#36d386', { threshold: 156 }) // #fff
 ```
 
 The default options are:
 
-- `options.colors.white`: `#fff`;
-- `options.colors.black`: `#000`;
+- `options.colors.light`: `#fff`;
+- `options.colors.dark`: `#000`;
 - `options.threshold`: 128.
 
 ## Authors and License

--- a/__tests__/color-yiq.test.ts
+++ b/__tests__/color-yiq.test.ts
@@ -18,8 +18,10 @@ describe('yiq', () => {
 
   it('should use the color options passed by the user over the default ones', () => {
     const options: YiqUserOptions = {
-      white: '#ddd',
-      black: '#333'
+      colors: {
+        white: '#ddd',
+        black: '#333'
+      }
     };
 
     expect(yiq('#fff', options)).toBe('#333');

--- a/__tests__/color-yiq.test.ts
+++ b/__tests__/color-yiq.test.ts
@@ -1,4 +1,4 @@
-import yiq, { YiqOptions } from '../src/yiq';
+import yiq, { YiqUserOptions } from '../src/yiq';
 
 const equal = (array: string[], param: string) =>
   array.map((value) => yiq(value)).every((color) => color === param);
@@ -16,13 +16,23 @@ describe('yiq', () => {
     expect(() => yiq('#FalseHex')).toThrow(Error);
   });
 
-  it('should use the options passed by the user over the default ones', () => {
-    const options: YiqOptions = {
+  it('should use the color options passed by the user over the default ones', () => {
+    const options: YiqUserOptions = {
       white: '#ddd',
       black: '#333'
     };
 
     expect(yiq('#fff', options)).toBe('#333');
     expect(yiq('#000', options)).toBe('#ddd');
+  });
+
+  it('should use the threshold option passed by the user over the default one', () => {
+    expect(yiq('#36d386')).toBe('#000');
+    expect(yiq('#36d386', { threshold: 156 })).toBe('#fff');
+    expect(yiq('#36d398', { threshold: 156 })).toBe('#000');
+  });
+
+  it('should throw an error when an invalid threshold option is passed', () => {
+    expect(() => yiq('#ddd', { threshold: 256 })).toThrow(Error);
   });
 });

--- a/__tests__/color-yiq.test.ts
+++ b/__tests__/color-yiq.test.ts
@@ -19,8 +19,8 @@ describe('yiq', () => {
   it('should use the color options passed by the user over the default ones', () => {
     const options: YiqUserOptions = {
       colors: {
-        white: '#ddd',
-        black: '#333'
+        light: '#ddd',
+        dark: '#333'
       }
     };
 

--- a/__tests__/validator.test.ts
+++ b/__tests__/validator.test.ts
@@ -1,4 +1,4 @@
-import { isValidHex } from '../src/yiq';
+import { isValidHex, isValidThreshold } from '../src/yiq';
 
 describe('isValidHex validator', () => {
   it('should return true when a valid hex is passed', () => {
@@ -8,5 +8,20 @@ describe('isValidHex validator', () => {
 
   it('should return false when a invalid hex is passed', () => {
     expect(isValidHex('#IAmInvalid')).toBe(false);
+  });
+});
+
+describe('isValidThreshold validator', () => {
+  it('should return true when a value between 0 and 255 is passed', () => {
+    expect(isValidThreshold(0)).toBe(true);
+    expect(isValidThreshold(255)).toBe(true);
+    expect(isValidThreshold(128)).toBe(true);
+    expect(isValidThreshold(60)).toBe(true);
+    expect(isValidThreshold(160)).toBe(true);
+  });
+
+  it('should return false a value below 0 or over 255 is passed', () => {
+    expect(isValidThreshold(-1)).toBe(false);
+    expect(isValidThreshold(256)).toBe(false);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yiq",
   "version": "3.0.1",
-  "description": "Returns white when a color is dark and black when a color is light (and a little more).",
+  "description": "Returns light when a color is dark and dark when a color is light (and a little more).",
   "files": [
     "dist"
   ],

--- a/src/lib/color-yiq.ts
+++ b/src/lib/color-yiq.ts
@@ -3,8 +3,8 @@ import { isValidHex, isValidThreshold } from './utils/validation';
 
 const defaultOptions: YiqOptions = {
   colors: {
-    white: '#fff',
-    black: '#000'
+    light: '#fff',
+    dark: '#000'
   },
   threshold: 128
 };
@@ -34,5 +34,5 @@ export function colorYiq(colorHex: string, userOptions?: YiqUserOptions) {
 
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
-  return yiq >= options.threshold ? options.colors.black : options.colors.white;
+  return yiq >= options.threshold ? options.colors.dark : options.colors.light;
 }

--- a/src/lib/color-yiq.ts
+++ b/src/lib/color-yiq.ts
@@ -1,16 +1,23 @@
-import { YiqOptions } from './utils/types';
-import { isValidHex } from './utils/validation';
+import { YiqOptions, YiqUserOptions } from './utils/types';
+import { isValidHex, isValidThreshold } from './utils/validation';
 
 const defaultOptions: YiqOptions = {
   white: '#fff',
-  black: '#000'
+  black: '#000',
+  threshold: 128
 };
 
-export function colorYiq(colorHex: string, userOptions?: YiqOptions) {
+export function colorYiq(colorHex: string, userOptions?: YiqUserOptions) {
   const options = { ...defaultOptions, ...userOptions };
 
   if (!isValidHex(colorHex)) {
     throw new Error(`The value "${colorHex}" is not a valid hex color string.`);
+  }
+
+  if (!isValidThreshold(options.threshold)) {
+    throw new Error(
+      `The threshold option "${options.threshold}" must be between 0 and 255.`
+    );
   }
 
   if (colorHex.length === 4) {
@@ -25,5 +32,5 @@ export function colorYiq(colorHex: string, userOptions?: YiqOptions) {
 
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
-  return yiq >= 128 ? options.black : options.white;
+  return yiq >= options.threshold ? options.black : options.white;
 }

--- a/src/lib/color-yiq.ts
+++ b/src/lib/color-yiq.ts
@@ -2,8 +2,10 @@ import { YiqOptions, YiqUserOptions } from './utils/types';
 import { isValidHex, isValidThreshold } from './utils/validation';
 
 const defaultOptions: YiqOptions = {
-  white: '#fff',
-  black: '#000',
+  colors: {
+    white: '#fff',
+    black: '#000'
+  },
   threshold: 128
 };
 
@@ -32,5 +34,5 @@ export function colorYiq(colorHex: string, userOptions?: YiqUserOptions) {
 
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 
-  return yiq >= options.threshold ? options.black : options.white;
+  return yiq >= options.threshold ? options.colors.black : options.colors.white;
 }

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,7 +1,7 @@
 export interface YiqOptions {
   colors: {
-    white: string;
-    black: string;
+    light: string;
+    dark: string;
   };
   threshold: number;
 }

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,4 +1,7 @@
 export interface YiqOptions {
   white: string;
   black: string;
+  threshold: number;
 }
+
+export type YiqUserOptions = Partial<YiqOptions>;

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,6 +1,8 @@
 export interface YiqOptions {
-  white: string;
-  black: string;
+  colors: {
+    white: string;
+    black: string;
+  };
   threshold: number;
 }
 

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -1,3 +1,7 @@
 export function isValidHex(hex: string) {
   return /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(hex);
 }
+
+export function isValidThreshold(threshold: number) {
+  return threshold >= 0 && threshold <= 255;
+}


### PR DESCRIPTION
This adds a `threshold` option to override the default `128` to switch between white and black.

Note that as side-effect on the compiler level, this also makes `options.white` and `options.black` independently optional. I would've liked to keep null values [at the perimeter](https://effectivetypescript.com/2020/03/24/null-values-to-perimeter/), but that would only have been possible with a breaking change such as:
```ts
interface YiqOptions {
  colors?: {
    white: string;
    black: string;
  }
  threshold?: number;
}